### PR TITLE
Make ADMIXTOOLS $PATH checking more robust on different platforms

### DIFF
--- a/R/eigenstrat.R
+++ b/R/eigenstrat.R
@@ -125,7 +125,7 @@ filter_bed <- function(data, bed, remove = FALSE, outfile = tempfile(fileext = "
     return(data)
   }
 
-  if (system("bedtools", ignore.stdout = TRUE) != 0)
+  if (Sys.which("bedtools") == "")
     stop("bedtools is required for filtering, but is not in your $PATH")
 
   if (!file.exists(bed))

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -5,8 +5,8 @@
     path_check <- all(Sys.which(cmds) != "")
     if (!path_check) {
         packageStartupMessage(
-            "Not all ADMIXTOOLS binaries could be found in your $PATH variable.\n",
-            "At the very least, the following programs are recommended:\n    ",
+            "ADMIXTOOLS programs required by admixr are not in your $PATH variable.\n",
+            "At the very least, the following programs should be available:\n    ",
             paste(cmds, collapse = ", "),
             "\nMake sure to modify the $PATH variable in your .Renviron file so \n",
             "that it points to the directory containing the ADMIXTOOLS programs.\n")

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,13 +1,14 @@
 .onAttach <- function(libname, pkgname) {
-  # check for presence of an ADMIXTOOLS command on user's PATH and display
-  # a warning if it's not present
-  path_check <- system("command -v qpDstat", ignore.stdout = TRUE)
-  if (path_check != 0) {
-    packageStartupMessage(
-      "ADMIXTOOLS binaries could not be found in your $PATH.\n",
-      "Please make sure you have ADMIXTOOLS compiled and that all commands are in $PATH.",
-      "\nThen make sure to modify the $PATH variable in your .Renviron file",
-      " so that R can find the ADMIXTOOLS binaries (you can run 'echo \"PATH=$PATH\" >> .Renviron' in the shell)."
-    )
-  }
+  ## check for presence of an ADMIXTOOLS command on user's PATH and display
+    ## a warning if it's not present
+    cmds  <- c("qp3Pop", "qpDstat", "qpF4ratio", "qpAdm", "qpWave")
+    path_check <- all(Sys.which(cmds) != "")
+    if (!path_check) {
+        packageStartupMessage(
+            "Not all ADMIXTOOLS binaries could be found in your $PATH variable.\n",
+            "At the very least, the following programs are recommended:\n    ",
+            paste(cmds, collapse = ", "),
+            "\nMake sure to modify the $PATH variable in your .Renviron file so \n",
+            "that it points to the directory containing the ADMIXTOOLS programs.\n")
+    }
 }

--- a/tests/testthat/helper-functions.R
+++ b/tests/testthat/helper-functions.R
@@ -1,5 +1,5 @@
 admixtools_present <- function() {
-  system("which qpDstat", ignore.stdout = TRUE) == 0
+  Sys.which("qpDstat") != ""
 }
 
 read_pops <- function(filename, columns) {
@@ -23,12 +23,11 @@ snp_to_bed <- function(snp, bed) {
 }
 
 admixtools_path <- function() {
-  # ugly hack to enable testing on my macOS where I have ADMIXTOOLS
-  # binaries symlinked to ~/local/bin
-  if (system("uname", intern = TRUE) == "Darwin") {
-    return("~/local/AdmixTools-6.0/")
-  }
+    ## ugly hack to enable testing on my macOS where I have ADMIXTOOLS
+    ## binaries symlinked to ~/local/bin
+    if (system("uname", intern = TRUE) == "Darwin") {
+        return("~/local/AdmixTools-6.0/")
+    }
 
-  system("which qpDstat", intern = TRUE) %>%
-    stringr::str_replace("/bin.*", "")
+    stringr::str_replace(Sys.which("qpDstat"), "/bin.*", "")
 }

--- a/vignettes/qpAdm.Rmd
+++ b/vignettes/qpAdm.Rmd
@@ -128,9 +128,6 @@ First, let's download and install a development version of _admixr_ to
 get access to the new features, and download a small example data set:
 
 ```{r, message = FALSE, warning = FALSE, results = "hide"}
-# install the latest version of 'admixr' from Gihub:
-devtools::install_github("bodkan/admixr")
-
 library(admixr)
 
 snps <- eigenstrat(download_data())


### PR DESCRIPTION
Testing on various R-building servers revealed some issues with testing for the presence of ADMIXTOOLS binaries on $PATH. Switching to `Sys.which()`, which is R's general implementation of `which` on unix, should fix those problems.